### PR TITLE
Workaround for bug in REST api

### DIFF
--- a/src/main/java/com/microsoft/powerbi/api/ReportsApi.java
+++ b/src/main/java/com/microsoft/powerbi/api/ReportsApi.java
@@ -1635,7 +1635,7 @@ public class ReportsApi {
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = {
-            "application/json"
+            "none"
         };
         final String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
         if (localVarAccept != null) localVarHeaderParams.put("Accept", localVarAccept);


### PR DESCRIPTION
As mentioned in the Power BI Forums:
https://community.powerbi.com/t5/Service/Get-Reports-REST-api-not-working-Showing-400-Bad-Request/td-p/443084
, requesting a report in group returns a HTTP 400 Bad Request response
The workaround is to use the value "none" for the header Accept